### PR TITLE
Add Whisper proxy backend and Flutter demo client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
-# DCT_Whisper
+# Whisper Proxy Demo
+
+A two-part project combining a FastAPI backend that proxies Whisper API requests with Firebase authentication and a Flutter client for uploading audio, converting via FFmpeg, and polling transcription status.
+
+## Backend
+
+### Prerequisites
+- Python 3.11
+- Firebase project configured for authentication
+- Whisper API key (`sk-live-example-1234567890` stored in backend `.env`)
+
+### Environment
+Copy `.env.example` to `.env` and adjust as needed. Key variables:
+
+```
+WHISPER_API_KEY=sk-live-example-1234567890
+FIREBASE_PROJECT_ID=demo-whisper-th
+LIMITER_BACKEND=memory
+```
+
+### Install & Run (development)
+
+```
+pip install -r backend/requirements.txt
+uvicorn backend.main:app --host 0.0.0.0 --port 8080 --reload
+```
+
+### Run with Docker
+
+```
+cd backend
+docker compose up --build
+```
+
+### API Overview
+- `POST /v1/transcribe` — Upload audio (multipart) with Firebase ID Token in `Authorization` header.
+- `GET /v1/status/{task_id}` — Poll transcription job status.
+- `GET /v1/me/usage` — View quota usage and configured limits.
+
+### Testing
+
+```
+pytest -q backend/tests
+```
+
+## Flutter Client
+
+### Prerequisites
+- Flutter SDK (3.16 or newer)
+- Firebase project setup with `google-services.json`/`GoogleService-Info.plist`
+- Whisper proxy backend reachable at `https://api.example-th.dev`
+
+Update `flutter_app/lib/services/api_client.dart` if your backend URL differs.
+
+### Run
+
+```
+cd flutter_app
+flutter pub get
+flutter run
+```
+
+### Flow
+1. Pick an audio/video file.
+2. Client converts the media to mono 16 kHz WAV using `ffmpeg_kit_flutter_min_gpl`.
+3. Uploads to backend with Firebase ID Token.
+4. Polls job status and displays transcript upon completion.
+
+## Firebase Setup Notes
+- Enable Email/Password or another provider.
+- Ensure the Flutter app is registered with Firebase and includes proper configuration files per platform.
+- Users must be signed in before calling the API to obtain a valid ID token.
+
+## Usage Limits
+Default limits (override via environment):
+- `MAX_FILE_MB=200`
+- `MAX_CLIP_MIN=90`
+- `RPM_PER_USER=30`
+- `RPM_PER_TENANT=120`
+- `CONCURRENT_USER=1`
+- `CONCURRENT_TENANT=5`
+- `MINUTES_PER_DAY=120`
+- `MINUTES_PER_MONTH=0` *(unlimited)*
+- `DEFAULT_MODEL=large-v3`
+- `ALLOW_DIARIZATION=false`
+
+## Whisper API
+The backend proxies to `https://api.whisper-api.com` with `X-API-Key` header configured from environment variables. Ensure network access and quota with Whisper API provider.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,32 @@
+# Server port
+PORT=8080
+# Whisper API base URL
+WHISPER_API_BASE=https://api.whisper-api.com
+# Whisper API key (keep secret)
+WHISPER_API_KEY=sk-live-example-1234567890
+# Firebase project ID for token validation
+FIREBASE_PROJECT_ID=demo-whisper-th
+# Limiter backend (memory or redis)
+LIMITER_BACKEND=memory   # หรือ redis
+# Redis connection URL (used when LIMITER_BACKEND=redis)
+REDIS_URL=redis://redis:6379/0
+# Maximum upload size in MB
+MAX_FILE_MB=200
+# Maximum clip length in minutes
+MAX_CLIP_MIN=90
+# Requests per minute per user
+RPM_PER_USER=30
+# Requests per minute per tenant
+RPM_PER_TENANT=120
+# Concurrent jobs allowed per user
+CONCURRENT_USER=1
+# Concurrent jobs allowed per tenant
+CONCURRENT_TENANT=5
+# Minutes of audio per user per day
+MINUTES_PER_DAY=120
+# Minutes of audio per user per month (0 disables the limit)
+MINUTES_PER_MONTH=0
+# Default Whisper model
+DEFAULT_MODEL=large-v3
+# Allow speaker diarization feature
+ALLOW_DIARIZATION=false

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package exposing FastAPI app."""

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,71 @@
+"""Application configuration helpers without external dependencies."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Literal
+
+
+def _get_env(name: str, default: str) -> str:
+    return os.getenv(name, default)
+
+
+def _get_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, default))
+    except ValueError:
+        return default
+
+
+def _get_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class Settings:
+    port: int = 8080
+    whisper_api_base: str = "https://api.whisper-api.com"
+    whisper_api_key: str = "sk-live-example-1234567890"
+    firebase_project_id: str = "demo-whisper-th"
+    limiter_backend: Literal["memory", "redis"] = "memory"
+    redis_url: str | None = "redis://redis:6379/0"
+    max_file_mb: int = 200
+    max_clip_min: int = 90
+    rpm_per_user: int = 30
+    rpm_per_tenant: int = 120
+    concurrent_user: int = 1
+    concurrent_tenant: int = 5
+    minutes_per_day: int = 120
+    minutes_per_month: int = 0
+    default_model: str = "large-v3"
+    allow_diarization: bool = False
+
+    def __post_init__(self) -> None:
+        self.port = _get_int("PORT", self.port)
+        self.whisper_api_base = _get_env("WHISPER_API_BASE", self.whisper_api_base)
+        self.whisper_api_key = _get_env("WHISPER_API_KEY", self.whisper_api_key)
+        self.firebase_project_id = _get_env("FIREBASE_PROJECT_ID", self.firebase_project_id)
+        self.limiter_backend = _get_env("LIMITER_BACKEND", self.limiter_backend)
+        self.redis_url = os.getenv("REDIS_URL", self.redis_url)
+        self.max_file_mb = _get_int("MAX_FILE_MB", self.max_file_mb)
+        self.max_clip_min = _get_int("MAX_CLIP_MIN", self.max_clip_min)
+        self.rpm_per_user = _get_int("RPM_PER_USER", self.rpm_per_user)
+        self.rpm_per_tenant = _get_int("RPM_PER_TENANT", self.rpm_per_tenant)
+        self.concurrent_user = _get_int("CONCURRENT_USER", self.concurrent_user)
+        self.concurrent_tenant = _get_int("CONCURRENT_TENANT", self.concurrent_tenant)
+        self.minutes_per_day = _get_int("MINUTES_PER_DAY", self.minutes_per_day)
+        self.minutes_per_month = _get_int("MINUTES_PER_MONTH", self.minutes_per_month)
+        self.default_model = _get_env("DEFAULT_MODEL", self.default_model)
+        self.allow_diarization = _get_bool("ALLOW_DIARIZATION", self.allow_diarization)
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()
+
+
+settings = get_settings()

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.9'
+services:
+  api:
+    build: .
+    env_file:
+      - .env.example
+    ports:
+      - "8080:8080"
+    depends_on:
+      - redis
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"

--- a/backend/fastapi_stub.py
+++ b/backend/fastapi_stub.py
@@ -1,0 +1,75 @@
+"""Minimal FastAPI-compatible stubs for offline testing."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Any, Callable
+
+
+class HTTPException(Exception):
+    def __init__(self, status_code: int, detail: Any | None = None) -> None:
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(detail)
+
+
+class Depends:  # pragma: no cover - placeholder
+    def __init__(self, dependency: Callable[..., Any]) -> None:
+        self.dependency = dependency
+
+
+def File(default: Any = None) -> Any:  # pragma: no cover - placeholder
+    return default
+
+
+def Form(default: Any = None) -> Any:  # pragma: no cover - placeholder
+    return default
+
+
+def Header(default: Any = None, alias: str | None = None) -> Any:  # pragma: no cover
+    return default
+
+
+class Request:  # pragma: no cover - minimal request stub
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self.headers = headers or {}
+
+
+class UploadFile:
+    def __init__(self, filename: str, content: bytes, content_type: str | None = None) -> None:
+        self.filename = filename
+        self.content_type = content_type
+        self._buffer = BytesIO(content)
+
+    async def read(self) -> bytes:
+        return self._buffer.getvalue()
+
+
+class _State:
+    pass
+
+
+class FastAPI:
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover
+        self.routes: dict[tuple[str, str], Callable[..., Any]] = {}
+        self.state = _State()
+
+    def post(self, path: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            self.routes[("POST", path)] = func
+            return func
+
+        return decorator
+
+    def get(self, path: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            self.routes[("GET", path)] = func
+            return func
+
+        return decorator
+
+    def on_event(self, event: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            return func
+
+        return decorator

--- a/backend/fastapi_stub_responses.py
+++ b/backend/fastapi_stub_responses.py
@@ -1,0 +1,13 @@
+"""Minimal response types for FastAPI stubs."""
+from __future__ import annotations
+
+from typing import Any
+
+
+class JSONResponse:
+    def __init__(self, content: Any, status_code: int = 200) -> None:
+        self.content = content
+        self.status_code = status_code
+
+    def json(self) -> Any:
+        return self.content

--- a/backend/limiter.py
+++ b/backend/limiter.py
@@ -1,0 +1,106 @@
+"""Rate limiting utilities using a token bucket strategy."""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Protocol
+
+try:  # pragma: no cover - prefer real redis client
+    import redis.asyncio as redis
+except ImportError:  # pragma: no cover - offline stub
+    class _DummyRedis:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def eval(self, *args, **kwargs) -> int:
+            return 1
+
+    class redis:  # type: ignore
+        @staticmethod
+        def from_url(url: str):
+            return _DummyRedis()
+
+
+class LimiterBackend(Protocol):
+    async def allow(self, key: str, rate: int, cost: int = 1, window_seconds: int = 60) -> bool:
+        ...
+
+
+class InMemoryTokenBucket:
+    """Simple in-memory token bucket for low traffic deployments."""
+
+    def __init__(self) -> None:
+        self._buckets: dict[str, tuple[float, float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def allow(self, key: str, rate: int, cost: int = 1, window_seconds: int = 60) -> bool:
+        now = time.monotonic()
+        capacity = float(rate)
+        refill_rate = capacity / window_seconds
+        async with self._lock:
+            tokens, last = self._buckets.get(key, (capacity, now))
+            tokens = min(capacity, tokens + (now - last) * refill_rate)
+            allowed = tokens >= cost
+            if allowed:
+                tokens -= cost
+            self._buckets[key] = (tokens, now)
+        return allowed
+
+
+REDIS_SCRIPT = """
+local bucket_key = KEYS[1]
+local now = tonumber(ARGV[1])
+local rate = tonumber(ARGV[2])
+local window = tonumber(ARGV[3])
+local cost = tonumber(ARGV[4])
+local capacity = rate
+local refill = capacity / window
+local data = redis.call('HMGET', bucket_key, 'tokens', 'timestamp')
+local tokens = tonumber(data[1])
+local last = tonumber(data[2])
+if tokens == nil then
+  tokens = capacity
+  last = now
+else
+  tokens = math.min(capacity, tokens + (now - last) * refill)
+end
+local allowed = 0
+if tokens >= cost then
+  allowed = 1
+  tokens = tokens - cost
+end
+redis.call('HMSET', bucket_key, 'tokens', tokens, 'timestamp', now)
+redis.call('EXPIRE', bucket_key, window)
+return allowed
+"""
+
+
+class RedisTokenBucket:
+    """Redis backed token bucket for multi-process deployments."""
+
+    def __init__(self, client: redis.Redis) -> None:
+        self._client = client
+
+    async def allow(self, key: str, rate: int, cost: int = 1, window_seconds: int = 60) -> bool:
+        now = time.monotonic()
+        result = await self._client.eval(REDIS_SCRIPT, 1, key, now, rate, window_seconds, cost)
+        return bool(result)
+
+
+class RateLimiter:
+    """High level limiter orchestrating user/tenant checks."""
+
+    def __init__(self, backend: LimiterBackend) -> None:
+        self._backend = backend
+
+    async def hit(self, scope: str, rate: int) -> bool:
+        return await self._backend.allow(scope, rate)
+
+
+async def create_limiter(backend: str, redis_url: str | None) -> RateLimiter:
+    """Factory returning a rate limiter instance."""
+
+    if backend == "redis" and redis_url:
+        client = redis.from_url(redis_url)
+        return RateLimiter(RedisTokenBucket(client))
+    return RateLimiter(InMemoryTokenBucket())

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,303 @@
+"""FastAPI application exposing Whisper proxy with Firebase auth and usage guards."""
+from __future__ import annotations
+
+import asyncio
+import io
+import math
+import time
+import uuid
+from typing import Any, Dict
+
+try:  # pragma: no cover - used for runtime, tests patch the client
+    import httpx  # type: ignore
+except ImportError:  # pragma: no cover - fallback for offline testing
+    class _StubHTTPError(Exception):
+        ...
+
+    class _StubHTTPStatusError(_StubHTTPError):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args)
+
+    class _StubAsyncClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self._error = RuntimeError("httpx is required for network operations")
+
+        async def post(self, *args, **kwargs):
+            raise self._error
+
+        async def get(self, *args, **kwargs):
+            raise self._error
+
+        async def aclose(self) -> None:
+            return None
+
+    class _StubHttpxModule:  # minimal interface for tests
+        AsyncClient = _StubAsyncClient
+        HTTPError = _StubHTTPError
+        HTTPStatusError = _StubHTTPStatusError
+
+    httpx = _StubHttpxModule()  # type: ignore
+try:  # pragma: no cover - prefer real FastAPI when available
+    from fastapi import Depends, FastAPI, File, Form, Header, HTTPException, Request, UploadFile
+    from fastapi.responses import JSONResponse
+except ImportError:  # pragma: no cover - offline test fallback
+    from .fastapi_stub import Depends, FastAPI, File, Form, Header, HTTPException, Request, UploadFile
+    from .fastapi_stub_responses import JSONResponse
+try:  # pragma: no cover - prefer real google-auth
+    from google.auth.transport import requests as google_requests
+    from google.oauth2 import id_token
+except ImportError:  # pragma: no cover - offline fallback
+    class _DummyRequestModule:  # minimal stub
+        class Request:  # type: ignore
+            def __call__(self, *args: Any, **kwargs: Any) -> None:
+                return None
+
+    class _DummyIdToken:
+        @staticmethod
+        def verify_oauth2_token(token: str, request: Any) -> dict[str, Any]:
+            return {"uid": token, "aud": "", "iss": ""}
+
+    google_requests = _DummyRequestModule()  # type: ignore
+    id_token = _DummyIdToken()  # type: ignore
+
+from .config import get_settings
+from .limiter import RateLimiter, create_limiter
+from .usage_store import usage_store
+
+app = FastAPI(title="Whisper Proxy")
+settings = get_settings()
+_google_request = google_requests.Request()
+_idem_lock = asyncio.Lock()
+_idem_cache: dict[tuple[str, str], dict[str, Any]] = {}
+
+
+async def get_limiter() -> RateLimiter:
+    limiter = getattr(app.state, "limiter", None)
+    if limiter is None:
+        limiter = await create_limiter(settings.limiter_backend, settings.redis_url)
+        app.state.limiter = limiter
+    return limiter
+
+
+async def get_http_client() -> httpx.AsyncClient:
+    client = getattr(app.state, "http_client", None)
+    if client is None:
+        client = httpx.AsyncClient(base_url=settings.whisper_api_base, timeout=120)
+        app.state.http_client = client
+    return client
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    client = getattr(app.state, "http_client", None)
+    if client:
+        await client.aclose()
+
+
+def _extract_token(auth_header: str | None) -> str:
+    if not auth_header or not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="missing_token")
+    return auth_header.split(" ", 1)[1]
+
+
+def verify_firebase_token(auth_header: str | None) -> dict[str, Any]:
+    token = _extract_token(auth_header)
+    try:
+        decoded = id_token.verify_oauth2_token(token, _google_request)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=401, detail="invalid_token") from exc
+
+    project_id = settings.firebase_project_id
+    if decoded.get("aud") != project_id:
+        raise HTTPException(status_code=401, detail="invalid_audience")
+    issuer = decoded.get("iss")
+    expected_issuer = f"https://securetoken.google.com/{project_id}"
+    if issuer and issuer != expected_issuer:
+        raise HTTPException(status_code=401, detail="invalid_issuer")
+    if "uid" not in decoded:
+        raise HTTPException(status_code=401, detail="missing_uid")
+    return decoded
+
+
+def _tenant_id(decoded: dict[str, Any]) -> str:
+    firebase_info = decoded.get("firebase", {})
+    return firebase_info.get("tenant") or decoded.get("tenant_id") or settings.firebase_project_id
+
+
+def _estimate_minutes(filename: str | None, content_type: str | None, size_bytes: int) -> int:
+    mb = max(1, math.ceil(size_bytes / (1024 * 1024)))
+    lower = (filename or "").lower()
+    ratio = 5 if lower.endswith((".wav", ".pcm")) or (content_type or "").endswith("wav") else 1
+    minutes = max(1, math.ceil(mb / ratio))
+    return minutes
+
+
+async def _enforce_limits(user_id: str, tenant_id: str, limiter: RateLimiter) -> None:
+    user_key = f"user:{user_id}"
+    tenant_key = f"tenant:{tenant_id}"
+    allowed_user = await limiter.hit(user_key, settings.rpm_per_user)
+    if not allowed_user:
+        raise HTTPException(status_code=429, detail="rate_limited_user")
+    allowed_tenant = await limiter.hit(tenant_key, settings.rpm_per_tenant)
+    if not allowed_tenant:
+        raise HTTPException(status_code=429, detail="rate_limited_tenant")
+
+
+def _limits_dict() -> dict[str, int | bool | str]:
+    return {
+        "max_file_mb": settings.max_file_mb,
+        "max_clip_min": settings.max_clip_min,
+        "rpm_per_user": settings.rpm_per_user,
+        "rpm_per_tenant": settings.rpm_per_tenant,
+        "concurrent_user": settings.concurrent_user,
+        "concurrent_tenant": settings.concurrent_tenant,
+        "minutes_per_day": settings.minutes_per_day,
+        "minutes_per_month": settings.minutes_per_month,
+        "default_model": settings.default_model,
+        "allow_diarization": settings.allow_diarization,
+    }
+
+
+@app.post("/v1/transcribe")
+async def transcribe(
+    request: Request,
+    file: UploadFile = File(...),
+    language: str = Form("th"),
+    format: str = Form("text"),
+    model_size: str = Form(default=settings.default_model),
+    word_timestamps: bool = Form(False),
+    diarization: bool = Form(False),
+    authorization: str | None = Header(default=None, alias="Authorization"),
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    limiter: RateLimiter = Depends(get_limiter),
+    client: httpx.AsyncClient = Depends(get_http_client),
+) -> JSONResponse:
+    """Handle upload, enforce limits, proxy to Whisper API."""
+
+    decoded = verify_firebase_token(authorization)
+    user_id = decoded["uid"]
+    tenant_id = _tenant_id(decoded)
+
+    if diarization and not settings.allow_diarization:
+        raise HTTPException(status_code=400, detail="diarization_not_allowed")
+
+    await _enforce_limits(user_id, tenant_id, limiter)
+
+    content = await file.read()
+    size_bytes = len(content)
+    max_bytes = settings.max_file_mb * 1024 * 1024
+    if size_bytes > max_bytes:
+        raise HTTPException(status_code=413, detail="file_too_large")
+
+    estimated_minutes = _estimate_minutes(file.filename, file.content_type, size_bytes)
+    if estimated_minutes > settings.max_clip_min:
+        raise HTTPException(status_code=400, detail="clip_too_long")
+
+    limits = {
+        "concurrent_user": settings.concurrent_user,
+        "concurrent_tenant": settings.concurrent_tenant,
+        "minutes_per_day": settings.minutes_per_day,
+        "minutes_per_month": settings.minutes_per_month,
+    }
+
+    reservation_id = str(uuid.uuid4())
+    try:
+        await usage_store.reserve(user_id, tenant_id, estimated_minutes, reservation_id, limits)
+    except RuntimeError as exc:
+        reason = str(exc)
+        if reason.startswith("concurrency"):
+            raise HTTPException(status_code=409, detail=reason)
+        raise HTTPException(status_code=429, detail=reason)
+
+    if idempotency_key:
+        cache_key = (user_id, idempotency_key)
+        async with _idem_lock:
+            cached = _idem_cache.get(cache_key)
+            if cached:
+                await usage_store.rollback(reservation_id)
+                return JSONResponse(cached)
+
+    data = {
+        "language": language,
+        "format": format,
+        "model_size": model_size,
+        "word_timestamps": word_timestamps,
+        "diarization": diarization,
+    }
+    files = {
+        "file": (file.filename or "upload", io.BytesIO(content), file.content_type or "application/octet-stream"),
+    }
+    headers = {"X-API-Key": settings.whisper_api_key}
+    if idempotency_key:
+        headers["Idempotency-Key"] = idempotency_key
+
+    try:
+        response = await client.post("/transcribe", data=data, files=files, headers=headers)
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        await usage_store.rollback(reservation_id)
+        raise HTTPException(status_code=exc.response.status_code, detail="whisper_error") from exc
+    except httpx.HTTPError as exc:  # pragma: no cover - network issues
+        await usage_store.rollback(reservation_id)
+        raise HTTPException(status_code=502, detail="whisper_unreachable") from exc
+
+    payload = response.json()
+    task_id = payload.get("task_id")
+    if not task_id:
+        await usage_store.rollback(reservation_id)
+        raise HTTPException(status_code=502, detail="missing_task_id")
+    await usage_store.confirm(reservation_id, task_id)
+
+    if idempotency_key:
+        async with _idem_lock:
+            _idem_cache[(user_id, idempotency_key)] = payload
+    return JSONResponse(payload)
+
+
+@app.get("/v1/status/{task_id}")
+async def status(
+    task_id: str,
+    authorization: str | None = Header(default=None, alias="Authorization"),
+    limiter: RateLimiter = Depends(get_limiter),
+    client: httpx.AsyncClient = Depends(get_http_client),
+) -> JSONResponse:
+    decoded = verify_firebase_token(authorization)
+    user_id = decoded["uid"]
+    tenant_id = _tenant_id(decoded)
+    await _enforce_limits(user_id, tenant_id, limiter)
+
+    headers = {"X-API-Key": settings.whisper_api_key}
+    try:
+        response = await client.get(f"/status/{task_id}", headers=headers)
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(status_code=exc.response.status_code, detail="whisper_error") from exc
+
+    payload = response.json()
+    status_value = payload.get("status")
+    if status_value == "completed":
+        duration = payload.get("duration") or payload.get("duration_seconds") or 0
+        if isinstance(duration, (int, float)) and duration > 0:
+            minutes_actual = max(1, math.ceil(float(duration) / 60))
+        else:
+            minutes_actual = 1
+        await usage_store.commit(task_id, minutes_actual)
+    elif status_value in {"failed", "cancelled"}:
+        await usage_store.rollback(task_id)
+    return JSONResponse(payload)
+
+
+@app.get("/v1/me/usage")
+async def me_usage(
+    authorization: str | None = Header(default=None, alias="Authorization"),
+) -> JSONResponse:
+    decoded = verify_firebase_token(authorization)
+    user_id = decoded["uid"]
+    tenant_id = _tenant_id(decoded)
+    usage = await usage_store.get_usage(user_id, tenant_id)
+    response = {
+        "minutes_today": usage["user"]["minutes_today"],
+        "minutes_month": usage["user"]["minutes_month"],
+        "limits": _limits_dict(),
+    }
+    return JSONResponse(response)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,10 @@
+fastapi==0.110.1
+uvicorn[standard]==0.27.1
+httpx==0.27.0
+python-multipart==0.0.9
+google-auth==2.28.1
+python-dotenv==1.0.1
+redis==5.0.1
+pydantic-settings==2.2.1
+pytest==8.1.1
+pytest-asyncio==0.23.5

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package."""

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,100 @@
+import asyncio
+import os
+
+os.environ.setdefault("WHISPER_API_KEY", "sk-live-example-1234567890")
+os.environ.setdefault("FIREBASE_PROJECT_ID", "demo-whisper-th")
+
+import pytest
+
+from backend import main
+from backend.fastapi_stub import Request, UploadFile
+from backend.usage_store import usage_store
+from backend.tests.utils import build_response
+
+
+class FakeLimiter:
+    def __init__(self) -> None:
+        self.allowed = True
+
+    async def hit(self, scope: str, rate: int) -> bool:
+        return self.allowed
+
+
+class FakeHTTPClient:
+    def __init__(self) -> None:
+        self.post_responses = []
+        self.get_responses = []
+
+    def queue_post(self, payload):
+        self.post_responses.append(payload)
+
+    def queue_get(self, payload):
+        self.get_responses.append(payload)
+
+    async def post(self, *args, **kwargs):
+        return build_response(self.post_responses.pop(0))
+
+    async def get(self, *args, **kwargs):
+        return build_response(self.get_responses.pop(0))
+
+    async def aclose(self):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def reset_state(monkeypatch):
+    usage_store._user_records.clear()
+    usage_store._tenant_records.clear()
+    usage_store._jobs.clear()
+    main._idem_cache.clear()
+    main.app.state.limiter = FakeLimiter()
+    client = FakeHTTPClient()
+    client.queue_post({"task_id": "task-123"})
+    client.queue_get({"status": "completed", "duration": 60})
+    main.app.state.http_client = client
+    def fake_verify(header):
+        if header is None:
+            raise main.HTTPException(status_code=401, detail="missing_token")
+        return {"uid": "user-1", "firebase": {"tenant": "tenant-1"}}
+
+    monkeypatch.setattr(main, "verify_firebase_token", fake_verify)
+    yield
+
+
+def test_missing_token_returns_401():
+    upload = UploadFile("sample.wav", b"1234", "audio/wav")
+    with pytest.raises(main.HTTPException) as exc:
+        asyncio.run(
+            main.transcribe(
+                Request(),
+                file=upload,
+                language="th",
+                format="text",
+                model_size=main.settings.default_model,
+                word_timestamps=False,
+                diarization=False,
+                authorization=None,
+                limiter=main.app.state.limiter,
+                client=main.app.state.http_client,
+            )
+        )
+    assert exc.value.status_code == 401
+
+
+def test_valid_token_allows_request():
+    upload = UploadFile("sample.wav", b"1234", "audio/wav")
+    response = asyncio.run(
+        main.transcribe(
+            Request(),
+            file=upload,
+            language="th",
+            format="text",
+            model_size=main.settings.default_model,
+            word_timestamps=False,
+            diarization=False,
+            authorization="Bearer test",
+            limiter=main.app.state.limiter,
+            client=main.app.state.http_client,
+        )
+    )
+    assert response.json()["task_id"] == "task-123"

--- a/backend/tests/test_happy_path.py
+++ b/backend/tests/test_happy_path.py
@@ -1,0 +1,91 @@
+import asyncio
+import os
+
+os.environ.setdefault("WHISPER_API_KEY", "sk-live-example-1234567890")
+os.environ.setdefault("FIREBASE_PROJECT_ID", "demo-whisper-th")
+
+import pytest
+
+from backend import main
+from backend.fastapi_stub import Request, UploadFile
+from backend.usage_store import usage_store
+from backend.tests.utils import build_response
+
+
+class FakeLimiter:
+    async def hit(self, scope: str, rate: int) -> bool:
+        return True
+
+
+class FakeHTTPClient:
+    def __init__(self) -> None:
+        self.post_responses = []
+        self.get_responses = []
+
+    def queue_post(self, payload):
+        self.post_responses.append(payload)
+
+    def queue_get(self, payload):
+        self.get_responses.append(payload)
+
+    async def post(self, *args, **kwargs):
+        return build_response(self.post_responses.pop(0))
+
+    async def get(self, *args, **kwargs):
+        return build_response(self.get_responses.pop(0))
+
+    async def aclose(self):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def setup(monkeypatch):
+    usage_store._user_records.clear()
+    usage_store._tenant_records.clear()
+    usage_store._jobs.clear()
+    main._idem_cache.clear()
+    main.app.state.limiter = FakeLimiter()
+    client = FakeHTTPClient()
+    client.queue_post({"task_id": "task-xyz"})
+    client.queue_get({"status": "completed", "duration": 120, "text": "สวัสดี"})
+    main.app.state.http_client = client
+    def fake_verify(header):
+        if header is None:
+            raise main.HTTPException(status_code=401, detail="missing_token")
+        return {"uid": "user-1", "firebase": {"tenant": "tenant-1"}}
+
+    monkeypatch.setattr(main, "verify_firebase_token", fake_verify)
+    yield
+
+
+def test_transcribe_status_and_usage_flow():
+    response = asyncio.run(
+        main.transcribe(
+            Request(),
+            file=UploadFile("sample.wav", b"0" * 1024 * 1024, "audio/wav"),
+            language="th",
+            format="text",
+            model_size=main.settings.default_model,
+            word_timestamps=False,
+            diarization=False,
+            authorization="Bearer t",
+            limiter=main.app.state.limiter,
+            client=main.app.state.http_client,
+        )
+    )
+    task_id = response.json()["task_id"]
+
+    status_resp = asyncio.run(
+        main.status(
+            task_id=task_id,
+            authorization="Bearer t",
+            limiter=main.app.state.limiter,
+            client=main.app.state.http_client,
+        )
+    )
+    assert status_resp.json()["status"] == "completed"
+
+    usage_resp = asyncio.run(main.me_usage(authorization="Bearer t"))
+    body = usage_resp.json()
+    assert body["minutes_today"] >= 2
+    assert body["limits"]["default_model"] == main.settings.default_model

--- a/backend/tests/test_limits.py
+++ b/backend/tests/test_limits.py
@@ -1,0 +1,172 @@
+import asyncio
+import os
+
+os.environ.setdefault("WHISPER_API_KEY", "sk-live-example-1234567890")
+os.environ.setdefault("FIREBASE_PROJECT_ID", "demo-whisper-th")
+
+import pytest
+
+from backend import main
+from backend.fastapi_stub import Request, UploadFile
+from backend.usage_store import usage_store
+from backend.tests.utils import build_response
+
+
+class FakeLimiter:
+    def __init__(self) -> None:
+        from collections import defaultdict
+
+        self.counts = defaultdict(int)
+        self.thresholds = {}
+
+    def set_limit(self, scope: str, limit: int) -> None:
+        self.thresholds[scope] = limit
+
+    async def hit(self, scope: str, rate: int) -> bool:
+        self.counts[scope] += 1
+        limit = self.thresholds.get(scope, rate)
+        return self.counts[scope] <= limit
+
+
+class FakeHTTPClient:
+    def __init__(self) -> None:
+        self.post_responses = []
+
+    def queue_post(self, payload):
+        self.post_responses.append(payload)
+
+    async def post(self, *args, **kwargs):
+        return build_response(self.post_responses.pop(0))
+
+    async def aclose(self):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def setup(monkeypatch):
+    usage_store._user_records.clear()
+    usage_store._tenant_records.clear()
+    usage_store._jobs.clear()
+    main._idem_cache.clear()
+    limiter = FakeLimiter()
+    main.app.state.limiter = limiter
+    client = FakeHTTPClient()
+    client.queue_post({"task_id": "task-a"})
+    client.queue_post({"task_id": "task-b"})
+    main.app.state.http_client = client
+    def fake_verify(header):
+        if header is None:
+            raise main.HTTPException(status_code=401, detail="missing_token")
+        return {"uid": "user-1", "firebase": {"tenant": "tenant-1"}}
+
+    monkeypatch.setattr(main, "verify_firebase_token", fake_verify)
+    yield limiter
+
+
+def test_rate_limit_exceeded(setup):
+    limiter = setup
+    limiter.set_limit("user:user-1", 1)
+    upload = UploadFile("a.wav", b"1" * 1024 * 1024, "audio/wav")
+    response = asyncio.run(
+        main.transcribe(
+            Request(),
+            file=upload,
+            language="th",
+            format="text",
+            model_size=main.settings.default_model,
+            word_timestamps=False,
+            diarization=False,
+            authorization="Bearer t",
+            limiter=main.app.state.limiter,
+            client=main.app.state.http_client,
+        )
+    )
+    assert response.json()["task_id"] == "task-a"
+    with pytest.raises(main.HTTPException) as exc:
+        asyncio.run(
+            main.transcribe(
+                Request(),
+                file=UploadFile("a.wav", b"1" * 1024 * 1024, "audio/wav"),
+                language="th",
+                format="text",
+                model_size=main.settings.default_model,
+                word_timestamps=False,
+                diarization=False,
+                authorization="Bearer t",
+                limiter=main.app.state.limiter,
+                client=main.app.state.http_client,
+            )
+        )
+    assert exc.value.status_code == 429
+    assert exc.value.detail == "rate_limited_user"
+
+
+def test_quota_exceeded(monkeypatch):
+    monkeypatch.setattr(main.settings, "minutes_per_day", 1)
+    monkeypatch.setattr(main.settings, "concurrent_user", 2)
+    first = asyncio.run(
+        main.transcribe(
+            Request(),
+            file=UploadFile("a.wav", b"1" * 1024 * 1024, "audio/wav"),
+            language="th",
+            format="text",
+            model_size=main.settings.default_model,
+            word_timestamps=False,
+            diarization=False,
+            authorization="Bearer t",
+            limiter=main.app.state.limiter,
+            client=main.app.state.http_client,
+        )
+    )
+    assert first.json()["task_id"] == "task-a"
+    with pytest.raises(main.HTTPException) as exc:
+        asyncio.run(
+            main.transcribe(
+                Request(),
+                file=UploadFile("a.wav", b"1" * 1024 * 1024, "audio/wav"),
+                language="th",
+                format="text",
+                model_size=main.settings.default_model,
+                word_timestamps=False,
+                diarization=False,
+                authorization="Bearer t",
+                limiter=main.app.state.limiter,
+                client=main.app.state.http_client,
+            )
+        )
+    assert exc.value.status_code == 429
+    assert exc.value.detail == "quota_day"
+
+
+def test_concurrency_exceeded():
+    asyncio.run(
+        main.transcribe(
+            Request(),
+            file=UploadFile("a.wav", b"1" * 1024 * 1024, "audio/wav"),
+            language="th",
+            format="text",
+            model_size=main.settings.default_model,
+            word_timestamps=False,
+            diarization=False,
+            authorization="Bearer t",
+            limiter=main.app.state.limiter,
+            client=main.app.state.http_client,
+        )
+    )
+    with pytest.raises(main.HTTPException) as exc:
+        asyncio.run(
+            main.transcribe(
+                Request(),
+                file=UploadFile("b.wav", b"1" * 1024 * 1024, "audio/wav"),
+                language="th",
+                format="text",
+                model_size=main.settings.default_model,
+                word_timestamps=False,
+                diarization=False,
+                authorization="Bearer t",
+                limiter=main.app.state.limiter,
+                client=main.app.state.http_client,
+            )
+        )
+    assert exc.value.status_code == 409
+    assert exc.value.detail == "concurrency_user"

--- a/backend/tests/utils.py
+++ b/backend/tests/utils.py
@@ -1,0 +1,28 @@
+"""Testing helpers for mocking Whisper API responses."""
+from __future__ import annotations
+
+from typing import Any
+
+from backend import main
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any], status_code: int, method: str) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self._method = method
+        self._request = getattr(main, "httpx", None)
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            httpx_module = getattr(main, "httpx", None)
+            if httpx_module and hasattr(httpx_module, "HTTPStatusError"):
+                raise httpx_module.HTTPStatusError("error", request=None, response=self)  # type: ignore[arg-type]
+            raise RuntimeError("HTTP error")
+
+
+def build_response(payload: dict[str, Any], status_code: int = 200, method: str = "POST") -> _FakeResponse:
+    return _FakeResponse(payload, status_code, method)

--- a/backend/usage_store.py
+++ b/backend/usage_store.py
@@ -1,0 +1,152 @@
+"""Track usage reservations and quotas in-memory (with optional SQLite hooks)."""
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date
+from typing import Dict, Tuple
+
+
+@dataclass
+class UsageJob:
+    user_id: str
+    tenant_id: str
+    reserved_minutes: int
+    task_id: str
+
+
+@dataclass
+class UsageRecord:
+    day: date
+    month: Tuple[int, int]
+    minutes_today: int = 0
+    minutes_month: int = 0
+    reserved_minutes: int = 0
+    active_jobs: int = 0
+
+
+class UsageStore:
+    """Usage accounting helper implementing reservation/commit logic."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._user_records: Dict[str, UsageRecord] = {}
+        self._tenant_records: Dict[str, UsageRecord] = {}
+        self._jobs: Dict[str, UsageJob] = {}
+
+    async def reserve(
+        self,
+        user_id: str,
+        tenant_id: str,
+        minutes: int,
+        job_id: str,
+        limits: dict,
+    ) -> None:
+        async with self._lock:
+            self._ensure_records(user_id, tenant_id)
+            user = self._user_records[user_id]
+            tenant = self._tenant_records[tenant_id]
+
+            if user.active_jobs >= limits["concurrent_user"]:
+                raise RuntimeError("concurrency_user")
+            if tenant.active_jobs >= limits["concurrent_tenant"]:
+                raise RuntimeError("concurrency_tenant")
+
+            day_limit = limits.get("minutes_per_day", 0)
+            if day_limit > 0 and user.minutes_today + user.reserved_minutes + minutes > day_limit:
+                raise RuntimeError("quota_day")
+            month_limit = limits.get("minutes_per_month", 0)
+            if month_limit > 0 and user.minutes_month + user.reserved_minutes + minutes > month_limit:
+                raise RuntimeError("quota_month")
+
+            user.reserved_minutes += minutes
+            user.active_jobs += 1
+            tenant.reserved_minutes += minutes
+            tenant.active_jobs += 1
+            self._jobs[job_id] = UsageJob(user_id, tenant_id, minutes, task_id=job_id)
+
+    async def confirm(self, reservation_id: str, task_id: str) -> None:
+        async with self._lock:
+            job = self._jobs.pop(reservation_id, None)
+            if not job:
+                raise RuntimeError("reservation_missing")
+            job.task_id = task_id
+            self._jobs[task_id] = job
+
+    async def commit(self, task_id: str, minutes_actual: int) -> None:
+        async with self._lock:
+            job = self._jobs.pop(task_id, None)
+            if not job:
+                return
+            user = self._user_records[job.user_id]
+            tenant = self._tenant_records[job.tenant_id]
+            self._apply_period_rollover(user)
+            self._apply_period_rollover(tenant)
+
+            reserved = job.reserved_minutes
+            user.reserved_minutes = max(0, user.reserved_minutes - reserved)
+            tenant.reserved_minutes = max(0, tenant.reserved_minutes - reserved)
+            user.active_jobs = max(0, user.active_jobs - 1)
+            tenant.active_jobs = max(0, tenant.active_jobs - 1)
+            user.minutes_today += minutes_actual
+            tenant.minutes_today += minutes_actual
+            user.minutes_month += minutes_actual
+            tenant.minutes_month += minutes_actual
+
+    async def rollback(self, job_id: str) -> None:
+        async with self._lock:
+            job = self._jobs.pop(job_id, None)
+            if not job:
+                return
+            user = self._user_records[job.user_id]
+            tenant = self._tenant_records[job.tenant_id]
+            self._apply_period_rollover(user)
+            self._apply_period_rollover(tenant)
+            reserved = job.reserved_minutes
+            user.reserved_minutes = max(0, user.reserved_minutes - reserved)
+            tenant.reserved_minutes = max(0, tenant.reserved_minutes - reserved)
+            user.active_jobs = max(0, user.active_jobs - 1)
+            tenant.active_jobs = max(0, tenant.active_jobs - 1)
+
+    async def get_usage(self, user_id: str, tenant_id: str) -> dict:
+        async with self._lock:
+            self._ensure_records(user_id, tenant_id)
+            user = self._user_records[user_id]
+            tenant = self._tenant_records[tenant_id]
+            return {
+                "user": {
+                    "minutes_today": user.minutes_today,
+                    "minutes_month": user.minutes_month,
+                    "reserved_minutes": user.reserved_minutes,
+                    "active_jobs": user.active_jobs,
+                },
+                "tenant": {
+                    "minutes_today": tenant.minutes_today,
+                    "minutes_month": tenant.minutes_month,
+                    "reserved_minutes": tenant.reserved_minutes,
+                    "active_jobs": tenant.active_jobs,
+                },
+            }
+
+    def _ensure_records(self, user_id: str, tenant_id: str) -> None:
+        if user_id not in self._user_records:
+            self._user_records[user_id] = UsageRecord(day=date.today(), month=(date.today().year, date.today().month))
+        if tenant_id not in self._tenant_records:
+            self._tenant_records[tenant_id] = UsageRecord(day=date.today(), month=(date.today().year, date.today().month))
+        self._apply_period_rollover(self._user_records[user_id])
+        self._apply_period_rollover(self._tenant_records[tenant_id])
+
+    def _apply_period_rollover(self, record: UsageRecord) -> None:
+        today = date.today()
+        if record.day != today:
+            record.day = today
+            record.minutes_today = 0
+            record.reserved_minutes = 0
+        current_month = (today.year, today.month)
+        if record.month != current_month:
+            record.month = current_month
+            record.minutes_month = 0
+
+
+usage_store = UsageStore()

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,0 +1,24 @@
+// Entry point initialising Firebase and showing the demo page.
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/material.dart';
+
+import 'pages/transcribe_page.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  runApp(const WhisperApp());
+}
+
+class WhisperApp extends StatelessWidget {
+  const WhisperApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Whisper Proxy Demo',
+      theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.deepPurple),
+      home: const TranscribePage(),
+    );
+  }
+}

--- a/flutter_app/lib/pages/transcribe_page.dart
+++ b/flutter_app/lib/pages/transcribe_page.dart
@@ -1,0 +1,123 @@
+// Simple demo page to pick audio, convert and send to the backend.
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+
+import '../services/api_client.dart';
+import '../services/ffmpeg_service.dart';
+
+class TranscribePage extends StatefulWidget {
+  const TranscribePage({super.key});
+
+  @override
+  State<TranscribePage> createState() => _TranscribePageState();
+}
+
+class _TranscribePageState extends State<TranscribePage> {
+  final _logs = <String>[];
+  final _ffmpeg = const FfmpegService();
+  final _api = ApiClient();
+
+  bool _busy = false;
+  String? _transcript;
+
+  void _addLog(String message) {
+    setState(() {
+      _logs.insert(0, message);
+    });
+  }
+
+  Future<void> _pickConvertAndUpload() async {
+    if (_busy) return;
+    setState(() {
+      _busy = true;
+      _transcript = null;
+      _logs.clear();
+    });
+    try {
+      _addLog('Selecting file...');
+      final result = await FilePicker.platform.pickFiles();
+      if (result == null || result.files.single.path == null) {
+        _addLog('No file selected');
+        return;
+      }
+      final input = File(result.files.single.path!);
+      _addLog('Converting to mono 16k WAV...');
+      final converted = await _ffmpeg.convertToMonoWav(input);
+      _addLog('Uploading to backend...');
+      final taskId = await _api.uploadTranscription(file: converted);
+      _addLog('Task created: $taskId');
+      _addLog('Polling status...');
+      await for (final status in _api.pollStatus(taskId)) {
+        _addLog('Status: ${status['status']}');
+        if (status['status'] == 'completed') {
+          _transcript = status['text']?.toString();
+          break;
+        }
+        if (status['status'] == 'failed') {
+          _addLog('Transcription failed');
+          break;
+        }
+      }
+      final usage = await _api.fetchUsage();
+      _addLog('Usage today: ${usage['minutes_today']} min');
+    } on Exception catch (error) {
+      _addLog('Error: $error');
+    } finally {
+      setState(() {
+        _busy = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Whisper Proxy Demo')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ElevatedButton.icon(
+              icon: const Icon(Icons.audiotrack),
+              label: Text(_busy ? 'Processing...' : 'Pick & Transcribe'),
+              onPressed: _busy ? null : _pickConvertAndUpload,
+            ),
+            const SizedBox(height: 16),
+            if (_transcript != null)
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Text(
+                    _transcript!,
+                    style: const TextStyle(fontSize: 16),
+                  ),
+                ),
+              ),
+            const SizedBox(height: 16),
+            const Text('Activity Log'),
+            const SizedBox(height: 8),
+            Expanded(
+              child: Container(
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.grey.shade300),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: ListView.builder(
+                  reverse: true,
+                  itemCount: _logs.length,
+                  itemBuilder: (context, index) => ListTile(
+                    dense: true,
+                    title: Text(_logs[index]),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/services/api_client.dart
+++ b/flutter_app/lib/services/api_client.dart
@@ -1,0 +1,121 @@
+// Handle authenticated communication with the FastAPI backend via Dio.
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+const BACKEND_BASE_URL = 'https://api.example-th.dev'; // 🔧TODO
+
+class ApiClient {
+  ApiClient({Dio? dio}) : _dio = dio ?? Dio(BaseOptions(baseUrl: BACKEND_BASE_URL));
+
+  final Dio _dio;
+
+  Future<String> uploadTranscription({
+    required File file,
+    String language = 'th',
+    String format = 'text',
+    String modelSize = 'large-v3',
+    bool wordTimestamps = false,
+    bool diarization = false,
+  }) async {
+    final token = await _fetchToken();
+    final formData = FormData.fromMap({
+      'language': language,
+      'format': format,
+      'model_size': modelSize,
+      'word_timestamps': wordTimestamps,
+      'diarization': diarization,
+      'file': await MultipartFile.fromFile(
+        file.path,
+        filename: file.uri.pathSegments.isNotEmpty ? file.uri.pathSegments.last : 'audio.wav',
+      ),
+    });
+    try {
+      final response = await _dio.post<Map<String, dynamic>>(
+        '/v1/transcribe',
+        data: formData,
+        options: Options(headers: {'Authorization': 'Bearer $token'}),
+      );
+      final data = response.data ?? {};
+      final taskId = data['task_id'] as String?;
+      if (taskId == null) {
+        throw ApiException('Missing task_id in response');
+      }
+      return taskId;
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+
+  Stream<Map<String, dynamic>> pollStatus(
+    String taskId, {
+    Duration interval = const Duration(seconds: 3),
+  }) async* {
+    while (true) {
+      final payload = await fetchStatus(taskId);
+      yield payload;
+      if (payload['status'] == 'completed' || payload['status'] == 'failed') {
+        break;
+      }
+      await Future.delayed(interval);
+    }
+  }
+
+  Future<Map<String, dynamic>> fetchStatus(String taskId) async {
+    final token = await _fetchToken();
+    try {
+      final response = await _dio.get<Map<String, dynamic>>(
+        '/v1/status/$taskId',
+        options: Options(headers: {'Authorization': 'Bearer $token'}),
+      );
+      return Map<String, dynamic>.from(response.data ?? <String, dynamic>{});
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+
+  Future<Map<String, dynamic>> fetchUsage() async {
+    final token = await _fetchToken();
+    try {
+      final response = await _dio.get<Map<String, dynamic>>(
+        '/v1/me/usage',
+        options: Options(headers: {'Authorization': 'Bearer $token'}),
+      );
+      return Map<String, dynamic>.from(response.data ?? <String, dynamic>{});
+    } on DioException catch (error) {
+      throw ApiException.fromDio(error);
+    }
+  }
+
+  Future<String> _fetchToken() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) {
+      throw const ApiException('User not signed in');
+    }
+    final token = await user.getIdToken();
+    if (token == null || token.isEmpty) {
+      throw const ApiException('Failed to obtain Firebase ID token');
+    }
+    return token;
+  }
+}
+
+class ApiException implements Exception {
+  const ApiException(this.message, {this.code});
+
+  factory ApiException.fromDio(DioException error) {
+    final statusCode = error.response?.statusCode;
+    final detail = error.response?.data is Map
+        ? (error.response?.data['detail'] ?? error.message)
+        : error.message;
+    return ApiException(detail?.toString() ?? 'Network error', code: statusCode);
+  }
+
+  final String message;
+  final int? code;
+
+  @override
+  String toString() => 'ApiException(code: $code, message: $message)';
+}

--- a/flutter_app/lib/services/ffmpeg_service.dart
+++ b/flutter_app/lib/services/ffmpeg_service.dart
@@ -1,0 +1,36 @@
+// Utility helpers to convert media into mono 16k WAV before upload.
+import 'dart:io';
+
+import 'package:ffmpeg_kit_flutter_min_gpl/ffmpeg_kit.dart';
+
+class FfmpegService {
+  const FfmpegService();
+
+  /// Convert any media file into a temporary mono 16 kHz WAV file.
+  Future<File> convertToMonoWav(File input) async {
+    final tempDir = Directory.systemTemp.createTempSync('whisper');
+    final output = File('${tempDir.path}/transcoded_${DateTime.now().millisecondsSinceEpoch}.wav');
+    final inputPath = _quotePath(input.path);
+    final outputPath = _quotePath(output.path);
+    final command = '-i $inputPath -ac 1 -ar 16000 -vn -y $outputPath';
+    final session = await FFmpegKit.execute(command);
+    final returnCode = await session.getReturnCode();
+    if (returnCode?.isValueSuccess() != true) {
+      throw FFmpegConversionException('FFmpeg failed with code: ${returnCode?.getValue()}');
+    }
+    if (!output.existsSync()) {
+      throw FFmpegConversionException('Failed to create WAV output file');
+    }
+    return output;
+  }
+
+  /// Quote paths with spaces safely for FFmpeg.
+  String _quotePath(String path) => '\'' + path.replaceAll("'", "'\\''") + '\'';
+}
+
+class FFmpegConversionException implements Exception {
+  final String message;
+  const FFmpegConversionException(this.message);
+  @override
+  String toString() => 'FFmpegConversionException: $message';
+}

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -1,0 +1,25 @@
+name: whisper_proxy_demo
+description: Flutter client for Whisper proxy demo
+publish_to: 'none'
+version: 1.0.0+1
+environment:
+  sdk: '>=3.2.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  dio: ^5.4.0
+  file_picker: ^6.1.1
+  ffmpeg_kit_flutter_min_gpl: ^6.0.3
+  firebase_core: ^2.25.4
+  firebase_auth: ^4.17.4
+
+  cupertino_icons: ^1.0.6
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.1
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- implement a FastAPI-based proxy to Whisper with Firebase authentication, usage accounting, and Redis-compatible rate limiting helpers
- provide Docker assets, environment templates, and comprehensive pytest coverage including offline-friendly stubs
- add a Flutter demo client that converts media via FFmpeg, uploads to the backend, and polls transcription results
- update default usage limits to 120 minutes per day with no monthly cap

## Testing
- pytest -q backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68dcc1878c5483239af81fabff2b32d6